### PR TITLE
DEVELOPER-3505 Fix DevSuite 1.1 and CDK 2.2 links

### DIFF
--- a/products/cdk/get-started.adoc
+++ b/products/cdk/get-started.adoc
@@ -6,7 +6,7 @@
 
 The easiest way to install the Red Hat Container Development Kit is to use the Red Hat Development Suite installer.
 
-. Download the link:#{site.download_manager_file_base_url}/cdk/devsuite-1.1.0-GA-bundle-installer.exe[Red Hat Development Suite 1.1] installer
+. Download the link:#{site.download_manager_file_base_url}devsuite-1.1.0-GA-bundle-installer.exe[Red Hat Development Suite 1.1] installer
 . Double click on the downloaded file to launch the installer. If you have User Account Control enabled, you will need to click _Yes_ to allow  the installer to run with adminstrator-level permissions.
 . Enter your Red Hat Developers username and password, and click _Login_.
 +
@@ -80,9 +80,9 @@ For other Linux distributions, install Vagrant using the packages included with 
 Next, download the environment that matches your virtualization platform:
 
 // FIXME These will need to be updated for GA and later.
-* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-virtualbox.box[Red Hat Enterprise Linux 7.2 Vagrant box for VirtualBox, window='_blank']
-* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-25.x86_64.vagrant-libvirt.box[Red Hat Enterprise Linux 7.2 Vagrant box for KVM/libvirt, window='_blank']
-* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-26.x86_64.vagrant-hyperv.box[Red Hat Enterprise Linux 7.2 Vagrant box for Hyper-V, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-virtualbox.box[Red Hat Enterprise Linux 7.2 Vagrant box for VirtualBox, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-libvirt.box[Red Hat Enterprise Linux 7.2 Vagrant box for KVM/libvirt, window='_blank']
+* #{site.download_manager_base_url}/download-manager/file/rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-hyperv.box[Red Hat Enterprise Linux 7.2 Vagrant box for Hyper-V, window='_blank']
 
 ## Mac And Linux Step3
 

--- a/products/devsuite/get-started.adoc
+++ b/products/devsuite/get-started.adoc
@@ -6,7 +6,7 @@
 
 Use the Red Hat Development Suite installer to get the latest development tools from Red Hat:
 
-. Download the link:#{site.download_manager_file_base_url}cdk/devsuite-1.1.0-GA-bundle-installer.exe[Red Hat Development Suite 1.1] installer
+. Download the link:#{site.download_manager_file_base_url}devsuite-1.1.0-GA-bundle-installer.exe[Red Hat Development Suite 1.1] installer
 . Double click on the downloaded file to launch the installer. If you have User Account Control enabled, you will need to click _Yes_ to allow  the installer to run with adminstrator-level permissions.
 . Enter your Red Hat Developers username and password, and click _Login_.
 +


### PR DESCRIPTION
- path changed for devsuite to no longer use /cdk/
- vagrant boxes updated to -29 (2.2 version) 
